### PR TITLE
Dependabot group minor/patch updates and check weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,20 @@ updates:
   - package-ecosystem: "maven"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     target-branch: "master"
     labels:
       - "maintenance"
+    # Group minor updates and patch updates, except for spring-boot-starter-parent updates,
+    # and create separate PRs for updates that do not match any grouping rule.
+    groups:
+      minor-updates:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+        exclude-patterns:
+          - "*spring-boot-starter-parent*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
- group minor and patch updates together, to reduce the number of PRs
- switch from daily to weekly check