### PR TITLE
Skip gpg signing for test job in publish workflow

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -14,8 +14,8 @@ concurrency:
 jobs:
   test:
     uses: FAIRDataTeam/github-workflows/.github/workflows/maven-verify.yml@v3
-    secrets: inherit
     with:
+      mvn-options: -Dgpg.skip
       db-type: "mongodb"
       db-version: 8
   publish:


### PR DESCRIPTION
reverts #19 and skips gpg signing