### PR TITLE
Prevent tests during publish job in maven-publish workflow

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -22,3 +22,5 @@ jobs:
     needs: test
     uses: FAIRDataTeam/github-workflows/.github/workflows/maven-publish.yml@v3
     secrets: inherit
+    with:
+      mvn-options: -DskipTests

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.fairdatateam.security</groupId>
     <artifactId>spring-security-acl-mongodb</artifactId>
-    <version>6.0.2</version>
+    <version>6.0.4</version>
     <packaging>jar</packaging>
 
     <name>Spring Security ACL for MongoDB</name>


### PR DESCRIPTION
The deploy lifecycle command also runs tests by default, but after the removal of embedded mongo, this no longer works, as the publish job does not set up an external mongodb instance.
Anyway, it is not needed, because we already have a test job as well in the same workflow.